### PR TITLE
Avoid crash on invalid favorites

### DIFF
--- a/archiver/archiver.go
+++ b/archiver/archiver.go
@@ -137,6 +137,11 @@ func (au *ArchiverUser) Run() {
 						log.Error().Err(err).Msgf("获取投稿信息失败: %s", media.Title)
 						continue
 					}
+					// 当稿件失效或信息为空时跳过以避免空指针
+					if vinfo.Arc == nil || vinfo.Ecode != 0 {
+						log.Warn().Msgf("稿件已失效: %s", media.Title)
+						continue
+					}
 
 					// 路径模板替换
 

--- a/archiver/updater.go
+++ b/archiver/updater.go
@@ -79,7 +79,7 @@ func (au *ArchiverUser) UpdateVideoMeta() {
 				log.Error().Err(err).Msgf("获取投稿信息失败: %s", vmeta.Path)
 				continue
 			}
-			if vinfo.Ecode != 0 {
+			if vinfo.Arc == nil || vinfo.Ecode != 0 {
 				log.Warn().Msgf("稿件已失效: %s", vmeta.Meta.Title)
 				// 发送通知
 				if au.config.Notification != "" {


### PR DESCRIPTION
## Summary
- skip invalid or deleted videos during archiving to prevent nil pointer panic
- ignore invalid videos when updating metadata to avoid crashes

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c3d3183e04833180ae44127390749a